### PR TITLE
Change .main-container to #subgrid-container for "popular" subpage on Reddit

### DIFF
--- a/filterlist.txt
+++ b/filterlist.txt
@@ -29,7 +29,7 @@ www.facebook.com##ul.xuk3077.x78zum5.x1iyjqo2.xl56j7k.xe11lzi.x1vy8oqc.x88anuq>l
 www.facebook.com##ul.xuk3077.x78zum5.x1iyjqo2.xl56j7k.xe11lzi.x1vy8oqc.x88anuq>li:nth-child(5)
 
 www.reddit.com##shreddit-app[pagetype="home"] .main-container
-www.reddit.com##shreddit-app[pagetype="popular"] .main-container
+www.reddit.com##shreddit-app[pagetype="popular"] #subgrid-container
 www.reddit.com##shreddit-app[pagetype="all"] .main-container
 
 www.youtube.com##.ytp-show-tiles.videowall-endscreen.ytp-player-content.html5-endscreen


### PR DESCRIPTION
<h4>
I changed the filter to block the subgrid-container id for Reddit, because it has an additional news scroll list at the top.
This only occurs on the "popular" subpage, so that's why there's a change for this subpage only.
</h4>
<i>The picture below will clarify what I'm writing about (posts pixelated, because the contents are irrelevant)</i>
<br>
<img width="1368" height="939" alt="image" src="https://github.com/user-attachments/assets/a5d0408a-156d-4748-b91e-ffa83290023a" />
