### PR TITLE
Remove trending search results

### DIFF
--- a/filterlist.txt
+++ b/filterlist.txt
@@ -37,7 +37,16 @@ www.facebook.com##ul.xuk3077.x78zum5.x1iyjqo2.xl56j7k.xe11lzi.x1vy8oqc.x88anuq>l
 www.reddit.com##shreddit-app[pagetype="home"] .main-container
 www.reddit.com##shreddit-app[pagetype="popular"] #subgrid-container
 www.reddit.com##shreddit-app[pagetype="all"] .main-container
-www.reddit.com###reddit-trending-searches-partial-container
+
+! Start of Reddit trending dropdown rules
+! LOGGED IN rules
+www.reddit.com###section_0_pipeline_1_trending_query
+www.reddit.com###section_0_pipeline_1_trending_query ~ *
+
+! LOGGED OUT rules
+www.reddit.com###search-dropdown-results-container > div:has(svg[icon-name="trend"])
+www.reddit.com###search-dropdown-results-container > div:has(svg[icon-name="trend"]) ~ *
+! End of Reddit trending dropdown rules
 
 www.youtube.com##.ytp-show-tiles.videowall-endscreen.ytp-player-content.html5-endscreen
 www.youtube.com##ytd-browse[page-subtype="home"]


### PR DESCRIPTION
Before:
<img width="559" height="777" alt="image" src="https://github.com/user-attachments/assets/90da956c-ec5b-4eb0-9299-00cbe2d51d6a" />

After:
<img width="563" height="99" alt="image" src="https://github.com/user-attachments/assets/769f3d7b-18ae-4ec4-9c3f-cccee422afaf" />

Given my lack of knowledge of ublock origin syntax, I didn't figure out how to get rid of the Trending Today text. Some methods I tried:
1. Looking at the source, you'll notice a `.reddit-search-bar` element with an attribute of `data-faceplate-tracking-context`. I tried matching on this using the contains operator (`*=`) and looked for the default state of `"query":""` but I just didn't find a way to make it work for some reason.
2. I tried the `has-text` function inb ublock origin, but that didn't seem to work.

NOTE: I am using Brave, so [while they profess that they aim to achieve complete compatibility](https://support.brave.app/hc/en-us/articles/6449369961741-How-do-I-manage-adblock-filters-in-Brave), these failed attempts may just be bugs in Brave.