### PR TITLE
chore(ci): migrate release workflow to semantic-release and add .releaserc config

### DIFF
--- a/.github/workflows/automate.yml
+++ b/.github/workflows/automate.yml
@@ -28,43 +28,12 @@ jobs:
       - name: Run Splitter Script
         run: python split_list.py
 
-      - name: Sync Changes to Repo
-        id: sync
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add -f dist/
-          if [ -n "$(git status --porcelain)" ]; then
-            git commit -m "chore: auto-update domain filters [skip ci]"
-            git push origin main
-          else
-            echo "No changes detected."
-          fi
-
-      - name: Prepare Release Metadata
-        if: startsWith(github.event.head_commit.message, '!RELEASE')
-        id: meta
-        run: |
-          MSG="${{ github.event.head_commit.message }}"
-          
-          VERSION=$(echo "$MSG" | awk '{print $2}')
-          
-          BODY=$(echo "$MSG" | cut -d' ' -f3-)
-          
-          echo "tag=$VERSION" >> $GITHUB_OUTPUT
-          echo "body=$BODY" >> $GITHUB_OUTPUT
-
-      - name: Create GitHub Release
-        if: startsWith(github.event.head_commit.message, '!RELEASE')
-        uses: softprops/action-gh-release@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          tag_name: ${{ steps.meta.outputs.tag }}
-          name: ${{ steps.meta.outputs.tag }}
-          body: ${{ steps.meta.outputs.body }}
-          draft: false
-          prerelease: false
-          files: |
-            filterlist.txt
-            dist/*.txt
+          node-version: "lts/*"
+
+      - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx --package semantic-release@25.0.3 --package @semantic-release/commit-analyzer@13.0.1 --package @semantic-release/release-notes-generator@14.1.0 --package conventional-changelog-conventionalcommits@9.1.0 --package @semantic-release/github@12.0.6 --package @semantic-release/changelog@6.0.3 --package @semantic-release/git@10.0.1

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,43 @@
+﻿{
+  "branches": [
+    "main"
+  ],
+  "tagFormat": "${version}",
+  "debug": true,
+  "ci": true,
+  "dryRun": false,
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "docs/CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}",
+        "assets": [
+          "docs/CHANGELOG.md",
+          "filterlist.txt",
+          "dist/*.txt"
+        ]
+      }
+    ],
+    [
+      "@semantic-release/github"
+    ]
+  ]
+}

--- a/.releaserc
+++ b/.releaserc
@@ -37,7 +37,13 @@
       }
     ],
     [
-      "@semantic-release/github"
+      "@semantic-release/github",
+      {
+        "assets": [
+          "filterlist.txt",
+          "dist/*.txt"
+        ]
+      }
     ]
   ]
 }


### PR DESCRIPTION
Hi,

I'd like to contribute by integrating semantic-release for automated versioning and release management.

This change modernizes the release workflow by:
- **Automating version bumps** based on conventional commits (no more manual `!RELEASE` triggers)
- **Generating a changelog** automatically in `docs/CHANGELOG.md`
- **Streamlining the process** — the workflow now commits, pushes, and creates GitHub Releases in one go
- **Following industry standards** with semantic versioning and conventional commits

The `.releaserc` config handles all the heavy lifting, so releases are consistent and reproducible.

Note: I wasn't able to test this on a fork due to workflow limitations, so I'd appreciate if you could give it a try on your end. Feel free to adjust the changelog location or any other settings to match your preferences!

An example of the release process can be found on any of my repositories, such as [bulk-timestamp-archiver](https://github.com/mathisgauthey/bulk-timestamp-archiver)